### PR TITLE
Mesh update fixinteger

### DIFF
--- a/flowpm/mesh_utils.py
+++ b/flowpm/mesh_utils.py
@@ -55,13 +55,14 @@ def _cic_indexing(mesh, part, weight=None, name=None):
     if weight is not None:
       kernel = tf.multiply(tf.expand_dims(weight, axis=-1), kernel)
 
-    neighboor_coords = tf.cast(neighboor_coords, tf.int32)
+    #neighboor_coords = tf.cast(neighboor_coords, tf.int32)
 
     # Adding batch dimension to the neighboor coordinates
     batch_idx = tf.range(0, batch_size)
     batch_idx = tf.reshape(batch_idx, (batch_size, 1, 1, 1))
     b = tf.tile(batch_idx,
                 [1] + list(neighboor_coords.get_shape()[1:-1]) + [1])
+    b=tf.cast(b,tf.float32)
     neighboor_coords = tf.concat([b, neighboor_coords], axis=-1)
     return tf.reshape(neighboor_coords, part_shape[:-1] + [8, 4]), tf.reshape(
         kernel, part_shape[:-1] + [8])
@@ -85,9 +86,9 @@ def _cic_paint(mesh, neighboor_coords, kernel, shift, name=None):
 
     # TODO: Assert shift shape
     neighboor_coords = tf.reshape(neighboor_coords, (-1, 8, 4))
-    neighboor_coords = neighboor_coords + tf.reshape(tf.constant(shift),
+    neighboor_coords = neighboor_coords + tf.reshape(tf.constant(shift, dtype=tf.float32),
                                                      [1, 1, 4])
-
+    neighboor_coords = tf.cast(neighboor_coords, tf.int32) 
     update = tf.scatter_nd(neighboor_coords, tf.reshape(kernel, (-1, 8)),
                            [batch_size, nx, ny, nz])
 
@@ -115,9 +116,9 @@ def _cic_readout(mesh, neighboor_coords, kernel, shift, name=None):
 
     # TODO: Assert shift shape
     neighboor_coords = tf.reshape(neighboor_coords, (-1, 8, 4))
-    neighboor_coords = neighboor_coords + tf.reshape(tf.constant(shift),
+    neighboor_coords = neighboor_coords + tf.reshape(tf.constant(shift, dtype=tf.float32),
                                                      [1, 1, 4])
-
+    neighboor_coords = tf.cast(neighboor_coords, tf.int32)
     meshvals = tf.gather_nd(mesh, neighboor_coords)
 
     weightedvals = tf.multiply(meshvals, tf.reshape(kernel, (-1, 8)))
@@ -154,7 +155,7 @@ def cic_paint(mesh, part, halo_size, weight=None, name=None):
   """
   nk = mtf.Dimension("nk", 8)
   nl = mtf.Dimension("nl", 4)
-  part = add_nvtx(part, message='before cic_indexing', domain_name='cic_paint')
+  part = add_nvtx(part, message='part before cic_indexing', domain_name='cic_paint')
   indices, values = mtf.slicewise(
       _cic_indexing, [mesh, part],
       output_dtype=[tf.float32, tf.float32],
@@ -163,14 +164,15 @@ def cic_paint(mesh, part, halo_size, weight=None, name=None):
           mtf.Shape(part.shape.dims[:-1] + [nk])
       ],
       splittable_dims=mesh.shape[:-3] + part.shape[1:-1])
-  mesh = add_nvtx(mesh, message='before cic_paint', domain_name='cic_paint')
+  values = add_nvtx(values, message='values after cic_indexing and before cic_paint', domain_name='cic_paint')
+  mesh = add_nvtx(mesh, message='mesh before cic_paint', domain_name='cic_paint')
   mesh = mtf.slicewise(lambda x, y, z: _cic_paint(
       x, y, z, shift=[0, halo_size, halo_size, halo_size]),
                        [mesh, indices, values],
                        output_dtype=tf.float32,
                        output_shape=mesh.shape,
                        splittable_dims=mesh.shape[:-3] + part.shape[1:-1])
-  mesh = add_nvtx(mesh, message='after cic_paint', domain_name='cic_paint')
+  mesh = add_nvtx(mesh, message='mesh after cic_paint', domain_name='cic_paint')
   return mesh
 
 

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -1,5 +1,3 @@
-
-
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -1,4 +1,3 @@
-sys.path.insert(0,'..') 
 
 
 from mpi4py import MPI

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -6,8 +6,13 @@ import numpy as np
 import tensorflow.compat.v1 as tf
 tf.disable_v2_behavior()
 
+import nvtx.plugins.tf as nvtx_tf
+from nvtx.plugins.tf.estimator import NVTXHook
+
 import mesh_tensorflow as mtf
 from mesh_tensorflow.hvd_simd_mesh_impl import HvdSimdMeshImpl
+from mesh_tensorflow.nvtx_ops import add_nvtx
+
 
 import flowpm
 import flowpm.mesh_ops as mpm
@@ -127,6 +132,7 @@ def lpt_prototype(mesh,
 
   # Begin simulation
   initc = mtfpm.linear_field(mesh, shape, bs, nc, pk, kv)
+  initc = add_nvtx(initc, message='linear_field', domain_name='nbody')
 
   state = mtfpm.lpt_init_single(
       initc,
@@ -138,15 +144,21 @@ def lpt_prototype(mesh,
       part_shape[1:],
       antialias=True,
   )
+ # state= add_nvtx(state, message='after_init', domain_name='nbody')
+
   # Here we can run our nbody
   final_state = mtfpm.nbody_single(state, stages, lr_shape, hr_shape, kv_lr, halo_size)
+ #final_state= add_nvtx(final_state, message='after_nbody', domain_name='nbody')
 
   # paint the field
   final_field = mtf.zeros(mesh, shape=hr_shape)
   for block_size_dim in hr_shape[-3:]:
     final_field = mtf.pad(final_field, [halo_size, halo_size],
                           block_size_dim.name)
-  final_field = mesh_utils.cic_paint(final_field, final_state[0], halo_size)
+
+  final_state0 = add_nvtx(final_state[0], message='before_paint', domain_name='nbody')
+  final_field = mesh_utils.cic_paint(final_field, final_state0, halo_size)
+  final_field = add_nvtx(final_field, message='after_paint', domain_name='nbody')
   # Halo exchange
   for blocks_dim, block_size_dim in zip(hr_shape[1:4], final_field.shape[-3:]):
     final_field = mpm.halo_reduce(final_field, blocks_dim, block_size_dim,
@@ -195,8 +207,9 @@ def main(_):
   # Retrieve output of computation
   initc = lowering.export_to_tf_tensor(initial_conditions)
   result = lowering.export_to_tf_tensor(mesh_final_field)
+  nvtx_callback = NVTXHook(skip_n_steps=0, name='Train')
 
-  with tf.Session() as sess:
+  with tf.compat.v1.train.MonitoredSession(hooks=[nvtx_callback]) as sess:
     start = time.time()
     a, c = sess.run([initc, result])
     end = time.time()

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -1,3 +1,7 @@
+import sys
+sys.path.insert(0,'..') 
+
+
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 
@@ -20,7 +24,7 @@ import flowpm.mtfpm as mtfpm
 import flowpm.mesh_utils as mesh_utils
 
 from astropy.cosmology import Planck15
-from matplotlib import pyplot as plt
+#from matplotlib import pyplot as plt
 cosmology = Planck15
 
 tf.flags.DEFINE_integer("nc", 128, "Size of the cube")
@@ -28,13 +32,13 @@ tf.flags.DEFINE_integer("batch_size", 1, "Batch Size")
 tf.flags.DEFINE_float("box_size", 100, "Box Size [Mpc/h]")
 tf.flags.DEFINE_float("a0", 0.1, "initial scale factor")
 tf.flags.DEFINE_float("af", 1.0, "final scale factor")
-tf.flags.DEFINE_integer("nsteps", 10, "Number of time steps")
+tf.flags.DEFINE_integer("nsteps", 3, "Number of time steps")
 
-tf.flags.DEFINE_integer("hsize", 0, "halo size")
+tf.flags.DEFINE_integer("hsize", 32, "halo size")
 
 #mesh flags
-tf.flags.DEFINE_integer("nx", 4, "# blocks along x")
-tf.flags.DEFINE_integer("ny", 2, "# blocks along y")
+tf.flags.DEFINE_integer("nx", 1, "# blocks along x")
+tf.flags.DEFINE_integer("ny", 1, "# blocks along y")
 
 FLAGS = tf.flags.FLAGS
 
@@ -216,20 +220,22 @@ def main(_):
     ttime = (end - start)
     print('Time for ', mesh_shape, ' is : ', ttime)
 
-  if comm.rank == 0:  
-    plt.figure(figsize=(9, 3))
-    plt.subplot(121)
-    plt.imshow(a[0].sum(axis=2))
-    plt.title('Initial Conditions')
+  #if comm.rank == 0:  
+  #  plt.figure(figsize=(9, 3))
+  #  plt.subplot(121)
+  #  plt.imshow(a[0].sum(axis=2))
+  #  plt.title('Initial Conditions')
 
-    plt.subplot(122)
-    plt.imshow(c[0].sum(axis=2))
-    plt.title('Mesh TensorFlow')
-    plt.colorbar()
-    plt.savefig("mesh_nbody_%d-row:%d-col:%d.png" %
-              (FLAGS.nc, FLAGS.nx, FLAGS.ny))
-    plt.close()
-  exit(-1)
+  #  plt.subplot(122)
+  #  plt.imshow(c[0].sum(axis=2))
+  #  plt.title('Mesh TensorFlow')
+  #  plt.colorbar()
+  #  plt.savefig("mesh_nbody_%d-row:%d-col:%d.png" %
+  #            (FLAGS.nc, FLAGS.nx, FLAGS.ny))
+  #  plt.close()
+  exit(0)
+
 
 if __name__ == "__main__":
   tf.app.run(main=main)
+

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -21,7 +21,7 @@ import flowpm.mtfpm as mtfpm
 import flowpm.mesh_utils as mesh_utils
 
 from astropy.cosmology import Planck15
-#from matplotlib import pyplot as plt
+from matplotlib import pyplot as plt
 cosmology = Planck15
 
 tf.flags.DEFINE_integer("nc", 128, "Size of the cube")

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -12,7 +12,6 @@ tf.disable_v2_behavior()
 
 import mesh_tensorflow as mtf
 from mesh_tensorflow.hvd_simd_mesh_impl import HvdSimdMeshImpl
-from mesh_tensorflow.nvtx_ops import add_nvtx
 
 
 import flowpm

--- a/scripts/mesh_nbody_benchmark.py
+++ b/scripts/mesh_nbody_benchmark.py
@@ -1,4 +1,3 @@
-import sys
 sys.path.insert(0,'..') 
 
 
@@ -230,4 +229,3 @@ def main(_):
 
 if __name__ == "__main__":
   tf.app.run(main=main)
-

--- a/scripts/mesh_nbody_new_benchmark_idris.job
+++ b/scripts/mesh_nbody_new_benchmark_idris.job
@@ -20,7 +20,7 @@
 module purge
 
 # chargement des modules
-module load tensorflow-gpu/py3/2.4.1+nccl-2.8.3-1 nvidia-nsight-systems/2021.1.1
+module load tensorflow-gpu/py3/2.4.1+cuda-11.2 nvidia-nsight-systems/2021.1.1
 #module load tensorflow-gpu/py3/2.4.1+nccl-2.8.3-1
 
 # echo des commandes lancees
@@ -34,5 +34,5 @@ ln -s $JOBSCRATCH /tmp/nvidia
 #srun nvprof --profile-child-processes -f -o result-mesh_nbody-%p.nvvp /gpfslocalsup/pub/idrtools/bind_gpu.sh python -u mesh_nbody_benchmark.py --nc=512 --batch_size=1 --nx=2 --ny=2 --hsize=32
 
 # execution du code avec binding via bind_gpu.sh : 1 GPU pour 1 tache MPI.
-srun --unbuffered --mpi=pmi2 -o mesh_nbody_%t.log /gpfslocalsup/pub/idrtools/bind_gpu.sh nsys profile --stats=true -t nvtx,cuda,mpi -o result-%q{SLURM_TASK_PID} python -u mesh_nbody_benchmark.py --nc=128 --batch_size=1 --nx=2 --ny=2 --hsize=32 --nsteps=3
+srun --unbuffered --mpi=pmi2 -o mesh_nbody_%t.log /gpfslocalsup/pub/idrtools/bind_gpu.sh nsys profile --stats=true -t nvtx,cuda,mpi -o result-%q{SLURM_TASK_PID} python -u mesh_nbody_benchmark.py  --nc=128 --batch_size=1 --nx=2 --ny=2 --hsize=32 --nsteps=2
 

--- a/scripts/mesh_nbody_new_benchmark_idris.job
+++ b/scripts/mesh_nbody_new_benchmark_idris.job
@@ -34,5 +34,5 @@ ln -s $JOBSCRATCH /tmp/nvidia
 #srun nvprof --profile-child-processes -f -o result-mesh_nbody-%p.nvvp /gpfslocalsup/pub/idrtools/bind_gpu.sh python -u mesh_nbody_benchmark.py --nc=512 --batch_size=1 --nx=2 --ny=2 --hsize=32
 
 # execution du code avec binding via bind_gpu.sh : 1 GPU pour 1 tache MPI.
-srun --unbuffered --mpi=pmi2 -o mesh_nbody_%t.log /gpfslocalsup/pub/idrtools/bind_gpu.sh nsys profile --stats=true -t nvtx,cuda,mpi -o result-%q{SLURM_TASK_PID} python -u mesh_nbody_benchmark.py  --nc=128 --batch_size=1 --nx=2 --ny=2 --hsize=32 --nsteps=2
+srun --unbuffered --mpi=pmi2 -o mesh_nbody_%t.log /gpfslocalsup/pub/idrtools/bind_gpu.sh nsys profile --stats=true -t nvtx,cuda,mpi -o result-%q{SLURM_TASK_PID} python -u mesh_nbody_benchmark.py  --nc=128 --batch_size=1 --nx=2 --ny=2 --hsize=32 --nsteps=3
 

--- a/scripts/pyramid_nbody.py
+++ b/scripts/pyramid_nbody.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.insert(0,'..') 
+
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 
@@ -17,20 +20,20 @@ from astropy.cosmology import Planck15
 cosmology = Planck15
 tf.random.set_random_seed(200*comm.Get_rank())
 
-tf.flags.DEFINE_integer("nc", 512, "Size of the cube")
+tf.flags.DEFINE_integer("nc", 128, "Size of the cube")
 tf.flags.DEFINE_integer("batch_size", 1, "Batch Size")
 tf.flags.DEFINE_float("box_size", 512, "Box Size [Mpc/h]")
 tf.flags.DEFINE_float("a0", 0.1, "initial scale factor")
 tf.flags.DEFINE_float("af", 1.0, "final scale factor")
-tf.flags.DEFINE_integer("nsteps", 10, "Number of time steps")
+tf.flags.DEFINE_integer("nsteps", 3, "Number of time steps")
 
 #pyramid flags
 tf.flags.DEFINE_integer("dsample", 2, "downsampling factor")
 tf.flags.DEFINE_integer("hsize", 32, "halo size")
 
 #mesh flags
-tf.flags.DEFINE_integer("nx", 2, "# blocks along x")
-tf.flags.DEFINE_integer("ny", 2, "# blocks along y")
+tf.flags.DEFINE_integer("nx", 1, "# blocks along x")
+tf.flags.DEFINE_integer("ny", 1, "# blocks along y")
 
 FLAGS = tf.flags.FLAGS
 

--- a/scripts/pyramid_nbody.py
+++ b/scripts/pyramid_nbody.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.insert(0,'..') 
-
 from mpi4py import MPI
 comm = MPI.COMM_WORLD
 


### PR DESCRIPTION
Adding fix for inefficient addition and concatenation of tensors with integers.

Effectively:
Branched from `flowpm/mesh_update_nvtx`  written together with @dlanzieri  after the IDRIS hackathon and removed `nvtx` references and other minor additions/comments of the past few days.

