### PR TITLE
Use stateless_normal to ensure that `flowpm.utils.white_noise` is deterministic

### DIFF
--- a/flowpm/utils.py
+++ b/flowpm/utils.py
@@ -343,11 +343,18 @@ def white_noise(nc, batch_size=1, seed=None, type='complex', name="WhiteNoise"):
     if isinstance(nc, int):
       nc = [nc, nc, nc]
 
+    if seed is None:
+      # Generate random seed from default random generator
+      seed = tf.random.uniform(shape=[2], maxval=tf.int32.max, dtype=tf.int32)
+    else:
+      # Use given seed.
+      seed = (seed, 873214)
+
     white = tf.random.stateless_normal(
         shape=[batch_size] + nc,
         mean=0.,
         stddev=(nc[0] * nc[1] * nc[2])**0.5,
-        seed=(seed, 873214))
+        seed=seed)
     if type == 'real':
       return white
     elif type == 'complex':

--- a/flowpm/utils.py
+++ b/flowpm/utils.py
@@ -343,11 +343,11 @@ def white_noise(nc, batch_size=1, seed=None, type='complex', name="WhiteNoise"):
     if isinstance(nc, int):
       nc = [nc, nc, nc]
 
-    white = tf.random.normal(
+    white = tf.random.stateless_normal(
         shape=[batch_size] + nc,
         mean=0.,
         stddev=(nc[0] * nc[1] * nc[2])**0.5,
-        seed=seed)
+        seed=(seed, 873214))
     if type == 'real':
       return white
     elif type == 'complex':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 import numpy as np
 from numpy.testing import assert_allclose
 
-from flowpm.utils import cic_paint, cic_readout, r2c3d, c2r3d, r2c2d, c2r2d
+from flowpm.utils import cic_paint, cic_readout, r2c3d, c2r3d, r2c2d, c2r2d, white_noise
 from pmesh.pm import ParticleMesh
 
 np.random.seed(0)
@@ -72,3 +72,9 @@ def test_r2c2r_2D():
   rec = rfield.numpy()
 
   assert_allclose(base, rec, rtol=1e-09)
+
+
+def test_white_noise_seed():
+  a = white_noise(4, seed=12)
+  b = white_noise(4, seed=12)
+  assert np.all(a == b)


### PR DESCRIPTION
Due to complicated semantics of random seeds in tensorflow, `flowpm.utils.white_noise` was not actually deterministic as a function of the seed. This fixes that by making use of the [`tensorflow.random.stateless_normal`](https://www.tensorflow.org/api_docs/python/tf/random/stateless_normal) API.